### PR TITLE
Allow later iso8601 release

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ include = ["CHANGELOG.md", "qcs_api_client/py.typed"]
 [tool.poetry.dependencies]
 attrs = "^20.1.0"
 httpx = "^0.15.0"
-iso8601 = "^0.1.13"
+iso8601 = "^1.0"
 pydantic = "^1.7.2"
 pyjwt = "^1.7.1"
 python = "^3.6"


### PR DESCRIPTION
`iso8601` was updates a while ago.

https://github.com/micktwomey/pyiso8601/releases

Support for > 1 ensures that distributions are able to build their packages without patching.