### PR TITLE
Fix PEP517 build backend

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,5 +53,5 @@ multi_line_output = 3
 include_trailing_comma = true
 
 [build-system]
-requires = ["poetry>=1.0"]
-build-backend = "poetry.masonry.api"
+requires = ["poetry-core>=1.0.0"]
+build-backend = "poetry.core.masonry.api"


### PR DESCRIPTION
Poetry is a packing and dependency management utility for Python. poetry-core is the PEP 517 build backend intended to be a light weight, fully compliant, self-contained package allowing PEP 517 compatible build frontends to build Poetry managed projects.