### PR TITLE
Loosen `attrs` requirement

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ include = ["CHANGELOG.md", "qcs_api_client/py.typed"]
 
 
 [tool.poetry.dependencies]
-attrs = "^21.3.0"
+attrs = ">=21.3.0"
 httpx = "^0.23.0"
 iso8601 = "^1.0.2"
 pydantic = "^1.7.2"


### PR DESCRIPTION
Fixes https://github.com/rigetti/qcs-api-client-python/issues/9