### PR TITLE
upper bound on pydantic-settings

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ python-dateutil = "^2.8.1"
 rfc3339 = "^6.2"
 toml = "^0.10.2"
 PyJWT = "^2.4.0"
-pydantic-settings = "^2.2.1"
+pydantic-settings = ">=2.2.1,<2.9"
 tenacity = "^8.3.0"
 
 


### PR DESCRIPTION
`pydantic-settings` 2.9.0 dropped support for Python 3.8, and using 2.9.* with this project [apparently fails](https://rigetti.slack.com/archives/CTEKQEQQM/p1745329584333889).